### PR TITLE
Add some time helper functions

### DIFF
--- a/app/javascript/Clients/clientIdPage/time-helpers.js
+++ b/app/javascript/Clients/clientIdPage/time-helpers.js
@@ -1,0 +1,31 @@
+import { Interval, DateTime } from 'luxon';
+
+export function timeSince(
+  isoDate,
+  units = ['days', 'months', 'years'],
+  now = new Date()
+) {
+  return intervalUnits(
+    Interval.fromDateTimes(DateTime.fromISO(isoDate), DateTime.fromJSDate(now)),
+    units
+  );
+}
+
+function intervalUnits(interval, units) {
+  return units.reduce(
+    (accumulator, unit) => ({
+      ...accumulator,
+      [unit]: interval.count(unit) - 1, // intervals are half-open
+    }),
+    {}
+  );
+}
+
+export function toMostSignificantTimeUnit(
+  interval,
+  bins = ['years', 'months', 'days']
+) {
+  for (const unit of bins) {
+    if (interval[unit] > 0) return { unit: unit, value: interval[unit] };
+  }
+}

--- a/app/javascript/Clients/clientIdPage/time-helpers.test.js
+++ b/app/javascript/Clients/clientIdPage/time-helpers.test.js
@@ -1,0 +1,53 @@
+import { timeSince, toMostSignificantTimeUnit } from './time-helpers';
+import { Interval, DateTime } from 'luxon';
+
+describe('timeSince', () => {
+  it('returns interval in different values', () => {
+    const { years } = timeSince(
+      '2000-01-01',
+      ['years'],
+      new Date('2000-01-01T00:00:00.000-08:00')
+    );
+    expect(years).toEqual(0);
+  });
+
+  it('determines interval to now by default', () => {
+    const interval = { count: jest.fn() };
+    jest
+      .spyOn(Interval, 'fromDateTimes')
+      .mockImplementationOnce(() => interval);
+    jest.spyOn(DateTime, 'fromISO').mockReturnValueOnce('FROM');
+    jest.spyOn(DateTime, 'fromJSDate').mockReturnValueOnce('NOW');
+    timeSince('2000-01-01');
+    expect(DateTime.fromJSDate.mock.calls[0][0] instanceof Date).toBe(true);
+    expect(DateTime.fromISO).toHaveBeenCalledWith('2000-01-01');
+    expect(Interval.fromDateTimes).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns interval in days, months, and years by default', () => {
+    const { days, months, years } = timeSince('2000-01-01');
+    expect(days).toEqual(jasmine.any(Number));
+    expect(months).toEqual(jasmine.any(Number));
+    expect(years).toEqual(jasmine.any(Number));
+  });
+});
+
+describe('toTimeUnitLargestDenomination', () => {
+  it('returns value in years', () => {
+    const interval = { years: 1, months: 12, days: 365 };
+    const { unit, value } = toMostSignificantTimeUnit(interval);
+    expect(unit).toBe('years');
+    expect(value).toBe(1);
+  });
+
+  it('returns value in months', () => {
+    const interval = { years: 0, months: 11, days: 365 };
+    const { unit, value } = toMostSignificantTimeUnit(interval);
+    expect(unit).toBe('months');
+    expect(value).toBe(11);
+  });
+
+  it('handles empty OK', () => {
+    expect(toMostSignificantTimeUnit({})).toBeFalsy();
+  });
+});


### PR DESCRIPTION
* [x] resolve cyclomatic complexity
* [x] use one datetime util
* [ ] replace the old impl

resolves the cyclomatic complexity raised in https://github.com/ca-cwds/case-management/blob/master/app/javascript/_utils/ageCalc/getAgeFormat.js#L4

implements with `luxon` instead of `moment` (see #194)