### PR TITLE
Revert "Update main jenkins build to publish correct sha for CC"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,6 @@ node('cm-slave') {
             }
             stage('Publish Coverage Reports') {
                 sh "docker cp ${container.id}:/app/coverage ./coverage"
-                sh "GIT_COMMIT=$(git log | grep -m1 -oE '[^ ]+$')"
                 sh "./cc-test-reporter format-coverage -p /app -t simplecov -o coverage/codeclimate.ruby.json coverage/ruby/.resultset.json"
                 sh "./cc-test-reporter format-coverage -p /app -t lcov -o coverage/codeclimate.javascript.json coverage/javascript/lcov.info"
                 sh "./cc-test-reporter sum-coverage coverage/codeclimate.*.json -p 2"


### PR DESCRIPTION
Reverts ca-cwds/case-management#238

see the comments in #238. Build is broke.